### PR TITLE
Add more detailed http error messages

### DIFF
--- a/client/netlify.toml
+++ b/client/netlify.toml
@@ -10,4 +10,4 @@
     NG_APP_SERVER_PROVIDER = 'heroku'
 
 [context.branch-deploy.environment]
-    NG_APP_SERVER_BASE_URL = 'https://realtime-chat-app-staging.up.railway.app'
+    NG_APP_SERVER_BASE_URL = 'https://floyds-messenger-staging.herokuapp.com'

--- a/client/src/app/services/base-http-client.service.ts
+++ b/client/src/app/services/base-http-client.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { Observable, of } from 'rxjs';
+import { Observable, of, OperatorFunction } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 import { promisifyObservable } from '../utils';
@@ -16,6 +16,7 @@ type OriginalHttpClientOptions<K extends keyof HttpClient & HttpMethods> = Param
 
 type HttpClientOptionsMap = {
     [method in HttpMethods]: OriginalHttpClientOptions<method> & {
+        disableErrorInterception?: boolean;
         // more options...
     };
 };
@@ -50,7 +51,10 @@ export class BaseHttpClient {
      * @param options The HTTP options to send with the request. */
     get<T>(endpoint: string, options?: HttpClientOptions<'get'>) {
         const url = this._baseUrl + endpoint;
-        return this.http.get<T>(url, this.addBearerToken(options)).pipe(this.getErrorInterceptor());
+        const response$ = this.http.get<T>(url, this.addBearerToken(options));
+
+        if (options?.disableErrorInterception) return response$;
+        return response$.pipe(this.getErrorInterceptor());
     }
 
     /**
@@ -67,8 +71,10 @@ export class BaseHttpClient {
      * @param options The HTTP options to send with the request. */
     post<T>(endpoint: string, body?: Record<string, any>, options?: HttpClientOptions<'post'>) {
         const url = this._baseUrl + endpoint;
+        const response$ = this.http.post<T>(url, body || {}, this.addBearerToken(options));
 
-        return this.http.post<T>(url, body || {}, this.addBearerToken(options)).pipe(this.getErrorInterceptor());
+        if (options?.disableErrorInterception) return response$;
+        return response$.pipe(this.getErrorInterceptor());
     }
 
     /**
@@ -77,14 +83,18 @@ export class BaseHttpClient {
      * @param options The HTTP options to send with the request */
     patch<T>(endpoint: string, body: Record<string, any>, options?: HttpClientOptions<'patch'>) {
         const url = this._baseUrl + endpoint;
+        const response$ = this.http.patch<T>(url, body, this.addBearerToken(options));
 
-        return this.http.patch<T>(url, body, this.addBearerToken(options)).pipe(this.getErrorInterceptor());
+        if (options?.disableErrorInterception) return response$;
+        return response$.pipe(this.getErrorInterceptor());
     }
 
     delete<T>(endpoint: string, options?: HttpClientOptions<'delete'>) {
         const url = this._baseUrl + endpoint;
+        const response$ = this.http.delete<T>(url, this.addBearerToken(options));
 
-        return this.http.delete<T>(url, this.addBearerToken(options)).pipe(this.getErrorInterceptor());
+        if (options?.disableErrorInterception) return response$;
+        return response$.pipe(this.getErrorInterceptor());
     }
 
     /** adds bearer token inside the 'headers'*/
@@ -101,20 +111,47 @@ export class BaseHttpClient {
     }
 
     /** catches errors and returns an `HttpServerErrorResponse` */
-    private getErrorInterceptor<T>() {
+    private getErrorInterceptor<T>(): OperatorFunction<T, T | HttpServerErrorResponse> {
         return catchError<T, Observable<HttpServerErrorResponse>>(({ type, ...err }: HttpErrorResponse) => {
-            console.warn('http error handler: An error occurred:', err.error, 'whole error res:', err);
+            console.warn("http error handler catched:'", err);
 
-            if (err.status === 0)
+            if (err.status !== 0) return of(err);
+
+            // check if client is connected to internet
+            if (!navigator.onLine)
                 return of({
                     ...err,
                     error: {
                         statusCode: 0,
-                        message: 'A network error occurred. Please check your internet connection and try again.',
-                        error: 'client-side or network error',
+                        message: 'You are offline. Please connect to the internet and try again.',
+                        error: 'network error',
                     },
                 });
-            else return of(err);
+
+            // check if the server is even up
+            return this.get<HttpServerErrorResponse>('/health', { disableErrorInterception: true }).pipe(
+                // server is up
+                map(() => ({
+                    ...err,
+                    error: {
+                        statusCode: 0,
+                        message:
+                            'An unkown error occurred. Please refresh and try again. If the problem presists, please report it.',
+                        error: 'unknown',
+                    },
+                })),
+                // server is down
+                catchError<HttpServerErrorResponse, Observable<HttpServerErrorResponse>>(err =>
+                    of({
+                        ...err,
+                        error: {
+                            statusCode: 0,
+                            message: 'We may be experiencing some issues with the server. Please report it.',
+                            error: 'server error',
+                        },
+                    }),
+                ),
+            );
         });
     }
 }

--- a/client/src/app/services/base-http-client.service.ts
+++ b/client/src/app/services/base-http-client.service.ts
@@ -122,7 +122,7 @@ export class BaseHttpClient {
                 return of({
                     ...err,
                     error: {
-                        statusCode: 0,
+                        statusCode: '0 - OFFLINE',
                         message: 'You are offline. Please connect to the internet and try again.',
                         error: 'network error',
                     },
@@ -145,7 +145,7 @@ export class BaseHttpClient {
                     of({
                         ...err,
                         error: {
-                            statusCode: 0,
+                            statusCode: '0 - SERVER DOWN',
                             message: 'We may be experiencing some issues with the server. Please report it.',
                             error: 'server error',
                         },

--- a/client/src/app/store/app.actions.ts
+++ b/client/src/app/store/app.actions.ts
@@ -1,10 +1,27 @@
-import { createAction, props } from '@ngrx/store';
+import { Action, createAction, props } from '@ngrx/store';
 import { HttpServerErrorResponse } from './app.model';
 
 export const appActions = {
-    nothing: createAction('[ GLOBAL ] nothing'),
+    nothing: createAction('[ APP ] nothing'),
     error: createAction(
-        '[ GLOBAL ] error',
-        props<(HttpServerErrorResponse | { errorMessage: string }) & { showToast?: boolean }>(),
+        '[ APP ] error',
+        props<
+            (HttpServerErrorResponse | { errorMessage: string }) & {
+                showToast?: boolean;
+                actionToRetry?: Action & Record<string, any>;
+            }
+        >(),
     ),
+
+    // @TODO: integrate into state
+    setInternetStatusOffline: createAction(
+        '[ APP ] set internet offline',
+        props<{ actionToRetry?: Action & Record<string, any> }>(),
+    ),
+    setInternetStatusOnline: createAction(
+        '[ APP ] set internet online',
+        props<{ actionToRetry?: Action & Record<string, any> }>(),
+    ),
+
+    retryAction: createAction('[ APP ] retry action', props<{ actionToRetry: Action & Record<string, any> }>()),
 };

--- a/client/src/app/store/app.effects.ts
+++ b/client/src/app/store/app.effects.ts
@@ -1,13 +1,13 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { catchError, mergeMap, tap } from 'rxjs/operators';
+import { catchError, filter, map, mergeMap, take, takeUntil, tap } from 'rxjs/operators';
 import { appActions } from './app.actions';
 import { HttpServerErrorResponse } from './app.model';
 import { ChatsEffects } from './chat/chat.effects';
 import { UserEffects } from './user/user.effects';
 import { HotToastService } from '@ngneat/hot-toast';
 import { Action } from '@ngrx/store';
-import { throwError, of, Observable } from 'rxjs';
+import { throwError, of, Observable, interval, OperatorFunction } from 'rxjs';
 import { ChatGroupEffects } from './chat/chat-group.effects';
 import { FriendshipEffects } from './chat/friendship.effects';
 
@@ -15,32 +15,131 @@ import { FriendshipEffects } from './chat/friendship.effects';
 class AppEffects {
     constructor(private actions$: Actions, private toastService: HotToastService) {}
 
-    logErrors = createEffect(
-        () =>
-            this.actions$.pipe(
-                ofType(appActions.error),
-                tap(({ type, showToast, ...action }) => {
-                    console.log('%csome error occurred:', 'color: red;', action);
+    logErrors = createEffect(() =>
+        this.actions$.pipe(
+            ofType(appActions.error),
+            tap(({ type, showToast, ...action }) => {
+                console.log('%csome error occurred:', 'color: red;', action);
 
-                    if (showToast === undefined) showToast = true;
-                    if (showToast === false) return;
+                if (showToast === undefined) showToast = true;
+                if (showToast === false) return;
 
-                    if ('errorMessage' in action) this.toastService.error(action.errorMessage);
-                    else if (typeof action.error?.message == 'string') this.toastService.error(action.error.message);
-                    else action.error?.message.forEach(msg => this.toastService.error(msg));
-                }),
-            ),
-        { dispatch: false },
+                if ('errorMessage' in action) this.toastService.error(action.errorMessage);
+                else if (typeof action.error?.message == 'string') this.toastService.error(action.error.message);
+                else action.error?.message.forEach(msg => this.toastService.error(msg));
+            }),
+            map(({ actionToRetry, ...err }) => {
+                if ('error' in err && err.error.statusCode == '0 - OFFLINE')
+                    return appActions.setInternetStatusOffline({ actionToRetry });
+                return appActions.nothing();
+            }),
+        ),
+    );
+
+    checking = false;
+    checkInternetConnection = createEffect(() => {
+        return this.actions$.pipe(
+            ofType(appActions.setInternetStatusOffline),
+            mergeMap(({ actionToRetry }) => {
+                if (this.checking) return of(appActions.nothing());
+
+                this.checking = true;
+                const maxAttempts = 25;
+                return interval(1000).pipe(
+                    takeUntil(this.actions$.pipe(ofType(appActions.setInternetStatusOnline))),
+                    take(maxAttempts),
+                    map(count => {
+                        if (count == maxAttempts - 1 && !navigator.onLine) throw new Error();
+                        return navigator.onLine;
+                    }),
+                    filter(isOnline => isOnline),
+                    this.toastService.observe({
+                        loading: 'Waiting for internet connection...',
+                        success: "You're back online.",
+                        error: 'Timeout - Could not get back online.',
+                    }),
+                    map(() => {
+                        this.checking = false;
+                        return appActions.setInternetStatusOnline({ actionToRetry });
+                    }),
+                    catchError(() => {
+                        this.checking = false;
+                        return of(appActions.nothing());
+                    }),
+                );
+            }),
+        );
+    });
+
+    forwardRetryAction = createEffect(() =>
+        this.actions$.pipe(
+            ofType(appActions.setInternetStatusOnline),
+            map(({ actionToRetry }) => {
+                if (actionToRetry) return appActions.retryAction({ actionToRetry });
+                return appActions.nothing();
+            }),
+        ),
+    );
+    retryAction = createEffect(() =>
+        this.actions$.pipe(
+            ofType(appActions.retryAction),
+            map(({ actionToRetry }) => {
+                this.toastService.info('Retrying...');
+                return actionToRetry;
+            }),
+        ),
     );
 }
 
 export const effects = [AppEffects, UserEffects, ChatsEffects, ChatGroupEffects, FriendshipEffects];
 
-export const handleError = <T, R>(dataOrError: T | HttpServerErrorResponse, actionCallback: (data: T) => R) => {
-    if ('error' in dataOrError) return appActions.error(dataOrError);
+export const handleError = <T, R>(
+    dataOrError: T | HttpServerErrorResponse,
+    actionCallback: (data: T) => R,
+    actionToRetry: Action & Record<string, any>,
+) => {
+    if ('error' in dataOrError) return appActions.error({ ...dataOrError, actionToRetry });
 
     return actionCallback(dataOrError);
 };
+
+type handleResponse = {
+    /** Checks for errors and mappes the response to an error action or the result of `onSuccess`. */
+    <T, SuccessA extends Action & Record<string, any>>(options: {
+        onSuccess: (data: T) => SuccessA;
+        actionToRetry: Action & Record<string, any>;
+        showToast?: boolean;
+    }): OperatorFunction<T | HttpServerErrorResponse, SuccessA | ReturnType<typeof appActions['error']>>;
+
+    /** Checks for errors and mappes the response to result of `onError` or `onSuccess` */
+    <T, ErrorA extends Action & Record<string, any>, SuccessA extends Action & Record<string, any>>(options: {
+        onError: (error: HttpServerErrorResponse) => ErrorA;
+        onSuccess: (data: T) => SuccessA;
+    }): OperatorFunction<T | HttpServerErrorResponse, ErrorA | SuccessA>;
+};
+
+/** Checks for errors and mappes the response to the result of either `onError`, `onSuccess` or error action, if `onError` is not given. */
+export const handleResponse: handleResponse = <
+    T,
+    ErrorA extends Action & Record<string, any>,
+    SuccessA extends Action & Record<string, any>,
+>({
+    onError,
+    onSuccess,
+    ...options
+}: {
+    onError?: (error: HttpServerErrorResponse) => ErrorA;
+    onSuccess: (data: T) => SuccessA;
+    actionToRetry?: Action & Record<string, any>;
+    showToast?: boolean;
+}) =>
+    map<T | HttpServerErrorResponse, ErrorA | SuccessA | ReturnType<typeof appActions['error']>>(dataOrError => {
+        if ('error' in dataOrError) {
+            if (onError) return onError(dataOrError);
+            return appActions.error({ ...dataOrError, ...options });
+        }
+        return onSuccess(dataOrError);
+    });
 
 export const throwIfErrorExists = () => {
     return mergeMap(<T>(dataOrError: T | HttpServerErrorResponse) =>
@@ -49,8 +148,8 @@ export const throwIfErrorExists = () => {
 };
 
 type ErrorAction = ReturnType<typeof appActions.error>;
-export const catchAndHandleError = (showToast = false) => {
+export const catchAndHandleError = (actionToRetry: Action & Record<string, any>, showToast = false) => {
     return catchError<Action, Observable<ErrorAction>>((err: HttpServerErrorResponse) =>
-        of(appActions.error({ ...err, showToast })),
+        of(appActions.error({ ...err, showToast, actionToRetry })),
     );
 };

--- a/client/src/app/store/app.model.ts
+++ b/client/src/app/store/app.model.ts
@@ -4,7 +4,7 @@ export interface HttpServerErrorResponse extends Omit<HttpErrorResponse, 'type'>
     error: {
         message: string | string[];
         error?: string;
-        statusCode: number;
+        statusCode: number | '0 - SERVER DOWN' | '0 - OFFLINE';
     };
 }
 

--- a/client/src/app/store/chat/chat.actions.ts
+++ b/client/src/app/store/chat/chat.actions.ts
@@ -18,6 +18,11 @@ export const chatActions = {
         '[ CHAT ] get joined chat previews success',
         props<{ chatPreviews: ChatPreview[] }>(),
     ),
+    loadChatPreview: createAction('[ CHAT ] load chat preview by id', props<{ chatId: string }>()),
+    loadChatPreviewSuccess: createAction(
+        '[ CHAT ] load chat preview by id succes',
+        props<{ chatPreview: ChatPreview }>(),
+    ),
 
     setActiveChat: createAction('[ CHAT ] set active', props<{ chatId: string }>()),
     setActiveChatSuccess: createAction('[ CHAT ] set active success', props<{ chatId: string }>()),
@@ -54,6 +59,10 @@ export const chatActions = {
         '[ FRIENDSHIP ] load received invitations',
         props<{ statusFilter: InvitationStatus }>(),
     ),
+    loadReceivedInvitation: createAction(
+        '[ FRIENDSHIP ] load received invitation from id',
+        props<{ invitationId: string }>(),
+    ),
     loadReceivedInvitationsSuccess: createAction(
         '[ FRIENDSHIP ] load received invitations success',
         props<{ invitations: ReceivedFriendshipInvitation[]; statusFilter: InvitationStatus }>(),
@@ -70,11 +79,6 @@ export const chatActions = {
             invitationId: string;
             invitationResponse: InvitationResponse;
         }>(),
-    ),
-
-    friendAcceptedInvitation: createAction(
-        '[ FRIENDSHIP ] friend accepted invitation',
-        props<{ chatPreview: ChatPreview }>(),
     ),
 
     loadSentInvitations: createAction('[ FRIENDSHIP ] load sent invitations'),

--- a/client/src/app/store/chat/chat.reducer.ts
+++ b/client/src/app/store/chat/chat.reducer.ts
@@ -70,6 +70,13 @@ export const chatsReducer = createReducer(
             chatPreviews: chatPreviews,
         };
     }),
+    // loaded chatPreview successfully
+    on(chatActions.loadChatPreviewSuccess, (state, { chatPreview }) => {
+        return {
+            ...state,
+            chatPreviews: [...state.chatPreviews, chatPreview],
+        };
+    }),
 
     // successfully created a chat
     on(chatActions.createChatSuccess, (state, { createdChat: { id, ...createdChat } }) => {
@@ -145,13 +152,6 @@ export const chatsReducer = createReducer(
                 pending: state.receivedInvitations.pending?.filter(invitation => invitation.id != invitationId),
                 [invitationsKey]: [...(state.receivedInvitations[invitationsKey] || []), invitation],
             },
-        };
-    }),
-    // friend accepted invitation
-    on(chatActions.friendAcceptedInvitation, (state, { chatPreview }) => {
-        return {
-            ...state,
-            chatPreviews: [...state.chatPreviews, chatPreview],
         };
     }),
 

--- a/client/src/environments/environment.prod.ts
+++ b/client/src/environments/environment.prod.ts
@@ -6,18 +6,21 @@ const provider = process.env.NG_APP_SERVER_PROVIDER;
 
 const urls = {
     heroku: {
-        prod: 'https://floyds-messenger-server.herokuapp.com',
+        prod: 'https://floyds-messenger-prod.herokuapp.com',
+        staging: 'https://floyds-messenger-staging.herokuapp.com',
         review: `https://floyds-messenger-pr-${reviewId}.herokuapp.com`,
     },
     railway: {
         prod: 'https://realtime-chat-app.up.railway.app',
+        staging: 'https://realtime-chat-app-staging.up.railway.app',
         review: `https://realtime-chat-app-realtime-chat-app-pr-${reviewId}.up.railway.app`,
     },
 };
 
 const url = {
     prod: urls[provider || 'heroku'].prod,
-    review: urls[provider || 'railway'].review,
+    staging: urls[provider || 'heroku'].staging,
+    review: urls[provider || 'heroku'].review,
 };
 
 export const environment = {

--- a/client/src/environments/environment.prod.ts
+++ b/client/src/environments/environment.prod.ts
@@ -1,6 +1,6 @@
 const isReviewEnv = process.env.NG_APP_PULL_REQUEST == 'true';
 const reviewId = process.env.NG_APP_REVIEW_ID;
-const provider = process.env.NG_APP_SERVER_PROVIDER;
+const provider = process.env.NG_APP_SERVER_PROVIDER || 'heroku';
 
 // @TODO: add staging env
 
@@ -18,9 +18,9 @@ const urls = {
 };
 
 const url = {
-    prod: urls[provider || 'heroku'].prod,
-    staging: urls[provider || 'heroku'].staging,
-    review: urls[provider || 'heroku'].review,
+    prod: urls[provider].prod,
+    staging: urls[provider].staging,
+    review: urls[provider].review,
 };
 
 export const environment = {

--- a/client/src/shared/chat-event-payloads.model.ts
+++ b/client/src/shared/chat-event-payloads.model.ts
@@ -26,6 +26,7 @@ export interface Server_NewFriendInvite {
 }
 export interface Server_AcceptFriendInvite {
     friendshipId: string;
+    friendName: string;
 }
 export interface Server_DeleteFriendInvite {
     invitationId: string;

--- a/server/src/app.controller.spec.ts
+++ b/server/src/app.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppController } from './app.controller';
+
+describe('AppController', () => {
+    let controller: AppController;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            controllers: [AppController],
+        }).compile();
+
+        controller = module.get<AppController>(AppController);
+    });
+
+    it('should be defined', () => {
+        expect(controller).toBeDefined();
+    });
+});

--- a/server/src/app.controller.ts
+++ b/server/src/app.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, InternalServerErrorException } from '@nestjs/common';
+
+@Controller()
+export class AppController {
+    @Get() root() {
+        return this.healthCheck();
+    }
+    @Get('/health') healthCheck() {
+        return { message: 'running' };
+    }
+    @Get('/dummy-error') dummyError() {
+        throw new InternalServerErrorException('You want errors? Here you go!');
+    }
+}

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -7,6 +7,7 @@ import { PrismaModule } from './prisma-abstractions/prisma.module';
 import { UsersModule } from './users/users.module';
 import { ChatPreviewsModule } from './chat-previews/chat-previews.module';
 import { SocketModule } from './socket/socket.module';
+import { AppController } from './app.controller';
 
 @Module({
     imports: [
@@ -21,7 +22,7 @@ import { SocketModule } from './socket/socket.module';
         ChatPreviewsModule,
         SocketModule,
     ],
-    controllers: [],
+    controllers: [AppController],
     providers: [],
     exports: [ConfigModule],
 })

--- a/server/src/friendships/friendships.service.ts
+++ b/server/src/friendships/friendships.service.ts
@@ -282,7 +282,7 @@ export class FriendshipsService {
 
         this.socketManager.addToSocketQueue({
             eventName: SocketEvents.SERVER__ACCEPT_FRIEND_INVITE,
-            payload: { friendshipId: friendship.id },
+            payload: { friendshipId: friendship.id, friendName: friend.username },
             userId: friend.id,
         });
 

--- a/server/src/shared/chat-event-payloads.model.ts
+++ b/server/src/shared/chat-event-payloads.model.ts
@@ -26,6 +26,7 @@ export interface Server_NewFriendInvite {
 }
 export interface Server_AcceptFriendInvite {
     friendshipId: string;
+    friendName: string;
 }
 export interface Server_DeleteFriendInvite {
     invitationId: string;


### PR DESCRIPTION
- [x] Add Healthcheck endpoint
- [x] Add further checks for error reasons
- [x] Add retry after online again

**Future implementations**
- [ ] Show a dialog instead of a toast when `statusCode == '0 -  SERVER DOWN'` and in review env
    - [ ] With links which can redirect to different environments (review, staging)